### PR TITLE
extension-point updateDisallowedUrls

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -164,7 +164,7 @@ class Robots extends RequestHandler
                 }
             }
         }
-
+        $this->extend('updateDisallowedUrls', $urls);
         return array_unique($urls);
     }
 


### PR DESCRIPTION
I used to use the extension-point `updateDisallowedUrls` from https://github.com/gorriecoe/silverstripe-robots/blob/master/src/Robots.php#L122 in [RobotsFoldersExtension](https://github.com/lerni/folderindex/blob/master/src/Extensions/RobotsFoldersExtension.php) and would like to have this available in this module as well. Is it possible to add this?